### PR TITLE
Add Windows support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,16 @@ module github.com/chelnak/ysmrr
 
 go 1.18
 
-require github.com/fatih/color v1.13.0
+require (
+	github.com/fatih/color v1.13.0
+	github.com/mattn/go-colorable v0.1.9
+	github.com/stretchr/testify v1.8.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/manager.go
+++ b/manager.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"runtime"
 	"time"
 
 	"github.com/chelnak/ysmrr/pkg/charmap"
 	"github.com/chelnak/ysmrr/pkg/colors"
 	"github.com/chelnak/ysmrr/pkg/tput"
+	"github.com/mattn/go-colorable"
 )
 
 // SpinnerManager manages spinners
@@ -51,7 +53,6 @@ func (sm *spinnerManager) AddSpinner(message string) *Spinner {
 		ErrorColor:    sm.errorColor,
 		MessageColor:  sm.messageColor,
 	}
-
 	spinner := NewSpinner(opts)
 	sm.spinners = append(sm.spinners, spinner)
 	return spinner
@@ -184,7 +185,7 @@ func NewSpinnerManager(options ...Option) SpinnerManager {
 		errorColor:    colors.FgHiRed,
 		completeColor: colors.FgHiGreen,
 		messageColor:  colors.NoColor,
-		writer:        os.Stdout,
+		writer:        getWriter(),
 		done:          make(chan bool),
 	}
 
@@ -193,6 +194,15 @@ func NewSpinnerManager(options ...Option) SpinnerManager {
 	}
 
 	return sm
+}
+
+func getWriter() io.Writer {
+	// Windows support conveniently provided by github.com/mattn/go-colorable <3.
+	if runtime.GOOS == "windows" {
+		return colorable.NewColorableStdout()
+	} else {
+		return os.Stdout
+	}
 }
 
 // WithCharMap sets the characters used for the spinners.


### PR DESCRIPTION
Prior to this commit the support for Windows was limited to modern terminal emulators.

This commit uses colorable.NewColorableStout() if we detect a windows OS. This handles the interpretation of the tput escape sequences and color printing.

Currently tested on Server 2019
* cmd.exe
* pwsh 7.2