### PR TITLE
Set frameDuration default

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -180,7 +180,7 @@ type Option func(*spinnerManager)
 func NewSpinnerManager(options ...Option) SpinnerManager {
 	sm := &spinnerManager{
 		chars:         charmap.Dots,
-		frameDuration: 250 * time.Millisecond,
+		frameDuration: 100 * time.Millisecond,
 		spinnerColor:  colors.FgHiGreen,
 		errorColor:    colors.FgHiRed,
 		completeColor: colors.FgHiGreen,


### PR DESCRIPTION
This PR changes the default frameDuration to 100 millisecond to allow for a smoother spinner animation.