### PR TITLE
Fix line rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,3 @@ Ysmrr was inspired by the following projects:
 
 It also uses [github.com/fatih/color](https://github.com/fatih/color) for the underlying color system
 and [github.com/mattn/go-colorable](https://github.com/mattn/go-colorable) for Windows support.
-
-

--- a/manager.go
+++ b/manager.go
@@ -144,8 +144,11 @@ func (sm *spinnerManager) GetMessageColor() colors.Color {
 // The render method also emits tput strings to the terminal to set the
 // correct location of the cursor.
 func (sm *spinnerManager) render() {
-	tput.Sc(sm.writer)
+	// Prepare the screen.
 	tput.Civis(sm.writer)
+	tput.BufScreen(sm.writer, len(sm.spinners))
+	tput.Cuu(sm.writer, len(sm.spinners))
+	tput.Sc(sm.writer)
 
 	for {
 		select {

--- a/pkg/tput/tput.go
+++ b/pkg/tput/tput.go
@@ -5,6 +5,7 @@ package tput
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Sc saves the current position of the cursor.
@@ -25,4 +26,15 @@ func Civis(w io.Writer) {
 // Cnorm shows the cursor.
 func Cnorm(w io.Writer) {
 	fmt.Fprintf(w, "\u001b[?25h")
+}
+
+// Cuu moves the cursor up by n lines.
+func Cuu(w io.Writer, n int) {
+	fmt.Fprintf(w, "\u001b[%dA", n)
+}
+
+// BufScreen ensures that there are enough lines available
+// by sending n * newlines to the writer.
+func BufScreen(w io.Writer, n int) {
+	fmt.Fprintf(w, "%s", strings.Repeat("\n", n))
 }

--- a/pkg/tput/tput_test.go
+++ b/pkg/tput/tput_test.go
@@ -3,6 +3,7 @@ package tput_test
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/chelnak/ysmrr/pkg/tput"
@@ -41,6 +42,36 @@ func TestTput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			tt.fn(&buf)
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestTputCommandsWithInputs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int
+		fn    func(w io.Writer, n int)
+		want  string
+	}{
+		{
+			name:  "Cuu",
+			input: 1,
+			fn:    tput.Cuu,
+			want:  "\u001b[1A",
+		},
+		{
+			name:  "BufScreen",
+			input: 10,
+			fn:    tput.BufScreen,
+			want:  strings.Repeat("\n", 10),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			tt.fn(&buf, tt.input)
 			assert.Equal(t, tt.want, buf.String())
 		})
 	}


### PR DESCRIPTION
This PR fixes a bug so that we will no longer encounter rendering issues when the application starts at the bottom of a terminal.

Two new commands have been added to the tput package:

* `Cuu` - moves the cursor up by n lines
* `BufScreen` -  print n * newline characters to the writer.

The manager now consumes the new tput commands so that we can always ensure that there is enough space to render our spinners.

Essentially before rendering starts we:
* Hide the cursor
* Print `len(sm.spinners) * \n`
* Move the cursor up `len(sm.spinners)`
* Save the cursor position

