### PR TITLE
Better charmap selection

### DIFF
--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	// Create a new spinner manager
 	sm := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Arrows),
+		ysmrr.WithCharMap(charmap.Pipe),
 		ysmrr.WithSpinnerColor(colors.FgHiBlue),
 	)
 

--- a/examples/basic_with_config/main.go
+++ b/examples/basic_with_config/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	// Create a new spinner manager
 	sm := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Arrows),
+		ysmrr.WithCharMap(charmap.Arrow),
 		ysmrr.WithSpinnerColor(colors.FgHiBlue),
 		ysmrr.WithMessageColor(colors.FgHiYellow),
 	)

--- a/manager.go
+++ b/manager.go
@@ -199,7 +199,7 @@ func (sm *spinnerManager) setNextFrame() {
 // 	)
 func NewSpinnerManager(options ...managerOption) SpinnerManager {
 	sm := &spinnerManager{
-		chars:         charmap.Dots,
+		chars:         charmap.GetCharMap(charmap.Dots),
 		frameDuration: 100 * time.Millisecond,
 		spinnerColor:  colors.FgHiGreen,
 		errorColor:    colors.FgHiRed,
@@ -231,9 +231,9 @@ type managerOption func(*spinnerManager)
 // WithCharMap sets the characters used for the spinners.
 // Available charmaps can be found in the package github.com/chelnak/ysmrr/pkg/charmap.
 // The default charmap is the Dots.
-func WithCharMap(chars []string) managerOption {
+func WithCharMap(c charmap.CharMap) managerOption {
 	return func(sm *spinnerManager) {
-		sm.chars = chars
+		sm.chars = charmap.GetCharMap(c)
 	}
 }
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var arrows = charmap.GetCharMap(charmap.Arrow)
+
 func TestNewSpinnerManager(t *testing.T) {
 	spinnerManager := ysmrr.NewSpinnerManager()
 	assert.NotNil(t, spinnerManager)
@@ -27,10 +29,10 @@ func TestNewSpinnerManager_WithWriter(t *testing.T) {
 
 func TestNewSpinnerManager_WithCharMap(t *testing.T) {
 	spinnerManager := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Arrows),
+		ysmrr.WithCharMap(charmap.Arrow),
 	)
 
-	assert.Equal(t, charmap.Arrows, spinnerManager.GetCharMap())
+	assert.Equal(t, arrows, spinnerManager.GetCharMap())
 }
 
 func TestNewSpinnerManager_WithFrameDuration(t *testing.T) {
@@ -58,10 +60,10 @@ func TestGetWriter(t *testing.T) {
 
 func TestGetCharMap(t *testing.T) {
 	spinnerManager := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Arrows),
+		ysmrr.WithCharMap(charmap.Arrow),
 	)
 
-	assert.Equal(t, charmap.Arrows, spinnerManager.GetCharMap())
+	assert.Equal(t, arrows, spinnerManager.GetCharMap())
 }
 
 func TestGetFrameDuration(t *testing.T) {

--- a/pkg/charmap/charmap.go
+++ b/pkg/charmap/charmap.go
@@ -1,27 +1,47 @@
 // Package charmap provides a collection of character maps to be used
 // with a spinner.
+// Spinners have been borrowed from the following sources:
+// * https://wiki.tcl-lang.org/page/Text+Spinner
+// * https://stackoverflow.com/questions/2685435/cooler-ascii-spinners
 package charmap
 
-var Dots = []string{
-	"⠋",
-	"⠙",
-	"⠹",
-	"⠸",
-	"⠼",
-	"⠴",
-	"⠦",
-	"⠧",
-	"⠇",
-	"⠏",
+type CharMap int
+
+const (
+	Arc CharMap = iota + 100
+	Arrow
+	Baloon
+	Baloon2
+	Circle
+	CircleHalves
+	CircleQuarters
+	Dots
+	Hamburger
+	Layer
+	Pipe
+	Point
+	Star
+	SquareCorners
+)
+
+var lookup = map[CharMap][]string{
+	Arc:            {"◜", "◠", "◝", "◞", "◡", "◟"},
+	Arrow:          {"←", "↖", "↑", "↗", "→", "↘", "↓", "↙"},
+	Baloon:         {".", "o", "O", "@", "*"},
+	Baloon2:        {".", "o", "O", "°", "O", "o", "."},
+	Circle:         {"◡", "⊙", "◠"},
+	CircleHalves:   {"◐", "◓", "◑", "◒"},
+	CircleQuarters: {"◴", "◷", "◶", "◵"},
+	Dots:           {"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+	Hamburger:      {"☱", "☲", "☴"},
+	Layer:          {"-", "=", "≡"},
+	Pipe:           {"┤", "┘", "┴", "└", "├", "┌", "┬", "┐"},
+	Point:          {"∙∙∙", "●∙∙", "∙●∙", "∙∙●", "∙∙∙"},
+	Star:           {"✶", "✸", "✹", "✺", "✹", "✷"},
+	SquareCorners:  {"◰", "◳", "◲", "◱"},
 }
 
-var Arrows = []string{
-	"←",
-	"↖",
-	"↑",
-	"↗",
-	"→",
-	"↘",
-	"↓",
-	"↙",
+// GetCharMap retirms a slice of strings for the given CharMap.
+func GetCharMap(c CharMap) []string {
+	return lookup[c]
 }

--- a/pkg/charmap/charmap_test.go
+++ b/pkg/charmap/charmap_test.go
@@ -1,0 +1,55 @@
+package charmap_test
+
+import (
+	"testing"
+
+	"github.com/chelnak/ysmrr/pkg/charmap"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	Arc            = []string{"◜", "◠", "◝", "◞", "◡", "◟"}
+	Arrow          = []string{"←", "↖", "↑", "↗", "→", "↘", "↓", "↙"}
+	Baloon         = []string{".", "o", "O", "@", "*"}
+	Baloon2        = []string{".", "o", "O", "°", "O", "o", "."}
+	Circle         = []string{"◡", "⊙", "◠"}
+	CircleHalves   = []string{"◐", "◓", "◑", "◒"}
+	CircleQuarters = []string{"◴", "◷", "◶", "◵"}
+	Dots           = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	Hamburger      = []string{"☱", "☲", "☴"}
+	Layer          = []string{"-", "=", "≡"}
+	Pipe           = []string{"┤", "┘", "┴", "└", "├", "┌", "┬", "┐"}
+	Point          = []string{"∙∙∙", "●∙∙", "∙●∙", "∙∙●", "∙∙∙"}
+	Star           = []string{"✶", "✸", "✹", "✺", "✹", "✷"}
+	SquareCorners  = []string{"◰", "◳", "◲", "◱"}
+)
+
+func TestCharMaps(t *testing.T) {
+	tests := []struct {
+		name string
+		c    charmap.CharMap
+		want []string
+	}{
+		{name: "Arc", c: charmap.Arc, want: Arc},
+		{name: "Arrow", c: charmap.Arrow, want: Arrow},
+		{name: "Baloon", c: charmap.Baloon, want: Baloon},
+		{name: "Baloon2", c: charmap.Baloon2, want: Baloon2},
+		{name: "Circle", c: charmap.Circle, want: Circle},
+		{name: "CircleHalves", c: charmap.CircleHalves, want: CircleHalves},
+		{name: "CircleQuarters", c: charmap.CircleQuarters, want: CircleQuarters},
+		{name: "Dots", c: charmap.Dots, want: Dots},
+		{name: "Hamburger", c: charmap.Hamburger, want: Hamburger},
+		{name: "Layer", c: charmap.Layer, want: Layer},
+		{name: "Pipe", c: charmap.Pipe, want: Pipe},
+		{name: "Point", c: charmap.Point, want: Point},
+		{name: "Star", c: charmap.Star, want: Star},
+		{name: "SquareCorners", c: charmap.SquareCorners, want: SquareCorners},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := charmap.GetCharMap(tt.c)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -71,9 +71,10 @@ func TestPrint(t *testing.T) {
 	spinner := ysmrr.NewSpinner(opts)
 
 	var buf bytes.Buffer
-	spinner.Print(&buf, charmap.Dots[0])
+	dots := charmap.GetCharMap(charmap.Dots)
+	spinner.Print(&buf, dots[0])
 
-	want := fmt.Sprintf("%s %s\r\n", charmap.Dots[0], initialMessage)
+	want := fmt.Sprintf("%s %s\r\n", dots[0], initialMessage)
 	assert.Equal(t, want, buf.String())
 }
 


### PR DESCRIPTION
Prior to this PR it was possible to mutate the charmaps stored in the charmap package because they were exported vars.

This commit changes the behaviour so that slices are retrieved by a lookup method.