### PR TITLE
Rename spinner package

### DIFF
--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -5,14 +5,14 @@ import (
 	"time"
 
 	"github.com/chelnak/ysmrr"
-	"github.com/chelnak/ysmrr/pkg/charmap"
+	"github.com/chelnak/ysmrr/pkg/animations"
 	"github.com/chelnak/ysmrr/pkg/colors"
 )
 
 func main() {
 	// Create a new spinner manager
 	sm := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Pipe),
+		ysmrr.WithAnimation(animations.Pipe),
 		ysmrr.WithSpinnerColor(colors.FgHiBlue),
 	)
 

--- a/examples/basic_with_config/main.go
+++ b/examples/basic_with_config/main.go
@@ -4,14 +4,14 @@ import (
 	"time"
 
 	"github.com/chelnak/ysmrr"
-	"github.com/chelnak/ysmrr/pkg/charmap"
+	"github.com/chelnak/ysmrr/pkg/animations"
 	"github.com/chelnak/ysmrr/pkg/colors"
 )
 
 func main() {
 	// Create a new spinner manager
 	sm := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Arrow),
+		ysmrr.WithAnimation(animations.Arrow),
 		ysmrr.WithSpinnerColor(colors.FgHiBlue),
 		ysmrr.WithMessageColor(colors.FgHiYellow),
 	)

--- a/manager.go
+++ b/manager.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/chelnak/ysmrr/pkg/charmap"
+	"github.com/chelnak/ysmrr/pkg/animations"
 	"github.com/chelnak/ysmrr/pkg/colors"
 	"github.com/chelnak/ysmrr/pkg/tput"
 	"github.com/mattn/go-colorable"
@@ -20,7 +20,7 @@ type SpinnerManager interface {
 	AddSpinner(msg string) *Spinner
 	GetSpinners() []*Spinner
 	GetWriter() io.Writer
-	GetCharMap() []string
+	GetAnimation() []string
 	GetFrameDuration() time.Duration
 	GetSpinnerColor() colors.Color
 	GetErrorColor() colors.Color
@@ -103,8 +103,9 @@ func (sm *spinnerManager) GetWriter() io.Writer {
 	return sm.writer
 }
 
-// GetCharMap returns the configured character map.
-func (sm *spinnerManager) GetCharMap() []string {
+// GetAnimation returns the current spinner animation as
+// a slice of strings.
+func (sm *spinnerManager) GetAnimation() []string {
 	return sm.chars
 }
 
@@ -182,24 +183,24 @@ func (sm *spinnerManager) setNextFrame() {
 //
 // For example, this will initialize a default manager:
 //
-//  sm := NewSpinnerManager()
+//	sm := NewSpinnerManager()
 //
-// Or this will initialize a manager with a custom character map:
+// Or this will initialize a manager with a custom animation:
 //
-// 	sm := NewSpinnerManager(
-// 		WithCharMap(charmap.Arrows)
-// 	)
+//	sm := NewSpinnerManager(
+//		WithAnimation(animations.Arrows)
+//	)
 //
 // You can pass in multiple options to the constructor:
 //
-// 	sm := NewSpinnerManager(
-// 		WithCharMap(charmap.Arrows),
-// 		WithFrameDuration(time.Millisecond * 100),
-// 		WithSpinnerColor(colors.Red),
-// 	)
+//	sm := NewSpinnerManager(
+//		WithAnimation(animations.Arrows),
+//		WithFrameDuration(time.Millisecond * 100),
+//		WithSpinnerColor(colors.Red),
+//	)
 func NewSpinnerManager(options ...managerOption) SpinnerManager {
 	sm := &spinnerManager{
-		chars:         charmap.GetCharMap(charmap.Dots),
+		chars:         animations.GetAnimation(animations.Dots),
 		frameDuration: 100 * time.Millisecond,
 		spinnerColor:  colors.FgHiGreen,
 		errorColor:    colors.FgHiRed,
@@ -228,12 +229,12 @@ func getWriter() io.Writer {
 // Option represents a spinner manager option.
 type managerOption func(*spinnerManager)
 
-// WithCharMap sets the characters used for the spinners.
-// Available charmaps can be found in the package github.com/chelnak/ysmrr/pkg/charmap.
-// The default charmap is the Dots.
-func WithCharMap(c charmap.CharMap) managerOption {
+// WithAnimation sets the animation used for the spinners.
+// Available spinner types can be found in the package github.com/chelnak/ysmrr/pkg/animations.
+// The default spinner animation is the Dots.
+func WithAnimation(a animations.Animation) managerOption {
 	return func(sm *spinnerManager) {
-		sm.chars = charmap.GetCharMap(c)
+		sm.chars = animations.GetAnimation(a)
 	}
 }
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -6,12 +6,12 @@ import (
 	"time"
 
 	"github.com/chelnak/ysmrr"
-	"github.com/chelnak/ysmrr/pkg/charmap"
+	"github.com/chelnak/ysmrr/pkg/animations"
 	"github.com/chelnak/ysmrr/pkg/colors"
 	"github.com/stretchr/testify/assert"
 )
 
-var arrows = charmap.GetCharMap(charmap.Arrow)
+var arrows = animations.GetAnimation(animations.Arrow)
 
 func TestNewSpinnerManager(t *testing.T) {
 	spinnerManager := ysmrr.NewSpinnerManager()
@@ -27,12 +27,12 @@ func TestNewSpinnerManager_WithWriter(t *testing.T) {
 	assert.Equal(t, &buf, spinnerManager.GetWriter())
 }
 
-func TestNewSpinnerManager_WithCharMap(t *testing.T) {
+func TestNewSpinnerManager_WithAnimation(t *testing.T) {
 	spinnerManager := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Arrow),
+		ysmrr.WithAnimation(animations.Arrow),
 	)
 
-	assert.Equal(t, arrows, spinnerManager.GetCharMap())
+	assert.Equal(t, arrows, spinnerManager.GetAnimation())
 }
 
 func TestNewSpinnerManager_WithFrameDuration(t *testing.T) {
@@ -58,12 +58,12 @@ func TestGetWriter(t *testing.T) {
 	assert.Equal(t, &buf, spinnerManager.GetWriter())
 }
 
-func TestGetCharMap(t *testing.T) {
+func TestGetAnimation(t *testing.T) {
 	spinnerManager := ysmrr.NewSpinnerManager(
-		ysmrr.WithCharMap(charmap.Arrow),
+		ysmrr.WithAnimation(animations.Arrow),
 	)
 
-	assert.Equal(t, arrows, spinnerManager.GetCharMap())
+	assert.Equal(t, arrows, spinnerManager.GetAnimation())
 }
 
 func TestGetFrameDuration(t *testing.T) {

--- a/pkg/animations/animations.go
+++ b/pkg/animations/animations.go
@@ -1,14 +1,13 @@
-// Package charmap provides a collection of character maps to be used
-// with a spinner.
-// Spinners have been borrowed from the following sources:
+// Package animations provides a collection of spinner animations.
+// Animations have been borrowed from the following sources:
 // * https://wiki.tcl-lang.org/page/Text+Spinner
 // * https://stackoverflow.com/questions/2685435/cooler-ascii-spinners
-package charmap
+package animations
 
-type CharMap int
+type Animation int
 
 const (
-	Arc CharMap = iota + 100
+	Arc Animation = iota + 100
 	Arrow
 	Baloon
 	Baloon2
@@ -24,7 +23,7 @@ const (
 	SquareCorners
 )
 
-var lookup = map[CharMap][]string{
+var lookup = map[Animation][]string{
 	Arc:            {"◜", "◠", "◝", "◞", "◡", "◟"},
 	Arrow:          {"←", "↖", "↑", "↗", "→", "↘", "↓", "↙"},
 	Baloon:         {".", "o", "O", "@", "*"},
@@ -41,7 +40,7 @@ var lookup = map[CharMap][]string{
 	SquareCorners:  {"◰", "◳", "◲", "◱"},
 }
 
-// GetCharMap retirms a slice of strings for the given CharMap.
-func GetCharMap(c CharMap) []string {
-	return lookup[c]
+// GetAnimation retirms a slice of strings for the given type.
+func GetAnimation(a Animation) []string {
+	return lookup[a]
 }

--- a/pkg/animations/animations_test.go
+++ b/pkg/animations/animations_test.go
@@ -1,9 +1,9 @@
-package charmap_test
+package animations_test
 
 import (
 	"testing"
 
-	"github.com/chelnak/ysmrr/pkg/charmap"
+	"github.com/chelnak/ysmrr/pkg/animations"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,31 +24,31 @@ var (
 	SquareCorners  = []string{"◰", "◳", "◲", "◱"}
 )
 
-func TestCharMaps(t *testing.T) {
+func TestAnimations(t *testing.T) {
 	tests := []struct {
 		name string
-		c    charmap.CharMap
+		s    animations.Animation
 		want []string
 	}{
-		{name: "Arc", c: charmap.Arc, want: Arc},
-		{name: "Arrow", c: charmap.Arrow, want: Arrow},
-		{name: "Baloon", c: charmap.Baloon, want: Baloon},
-		{name: "Baloon2", c: charmap.Baloon2, want: Baloon2},
-		{name: "Circle", c: charmap.Circle, want: Circle},
-		{name: "CircleHalves", c: charmap.CircleHalves, want: CircleHalves},
-		{name: "CircleQuarters", c: charmap.CircleQuarters, want: CircleQuarters},
-		{name: "Dots", c: charmap.Dots, want: Dots},
-		{name: "Hamburger", c: charmap.Hamburger, want: Hamburger},
-		{name: "Layer", c: charmap.Layer, want: Layer},
-		{name: "Pipe", c: charmap.Pipe, want: Pipe},
-		{name: "Point", c: charmap.Point, want: Point},
-		{name: "Star", c: charmap.Star, want: Star},
-		{name: "SquareCorners", c: charmap.SquareCorners, want: SquareCorners},
+		{name: "Arc", s: animations.Arc, want: Arc},
+		{name: "Arrow", s: animations.Arrow, want: Arrow},
+		{name: "Baloon", s: animations.Baloon, want: Baloon},
+		{name: "Baloon2", s: animations.Baloon2, want: Baloon2},
+		{name: "Circle", s: animations.Circle, want: Circle},
+		{name: "CircleHalves", s: animations.CircleHalves, want: CircleHalves},
+		{name: "CircleQuarters", s: animations.CircleQuarters, want: CircleQuarters},
+		{name: "Dots", s: animations.Dots, want: Dots},
+		{name: "Hamburger", s: animations.Hamburger, want: Hamburger},
+		{name: "Layer", s: animations.Layer, want: Layer},
+		{name: "Pipe", s: animations.Pipe, want: Pipe},
+		{name: "Point", s: animations.Point, want: Point},
+		{name: "Star", s: animations.Star, want: Star},
+		{name: "SquareCorners", s: animations.SquareCorners, want: SquareCorners},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := charmap.GetCharMap(tt.c)
+			got := animations.GetAnimation(tt.s)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/chelnak/ysmrr"
-	"github.com/chelnak/ysmrr/pkg/charmap"
+	"github.com/chelnak/ysmrr/pkg/animations"
 	"github.com/chelnak/ysmrr/pkg/colors"
 	"github.com/stretchr/testify/assert"
 )
@@ -71,7 +71,7 @@ func TestPrint(t *testing.T) {
 	spinner := ysmrr.NewSpinner(opts)
 
 	var buf bytes.Buffer
-	dots := charmap.GetCharMap(charmap.Dots)
+	dots := animations.GetAnimation(animations.Dots)
 	spinner.Print(&buf, dots[0])
 
 	want := fmt.Sprintf("%s %s\r\n", dots[0], initialMessage)


### PR DESCRIPTION
Prior to this PR `CharMap` was used to describe the animations that could be used with a spinner. 

The UX for this wasn't great because it wasn't really clear what a `CharMap` was.

This commit renames the spinner package to Animations. Types and methods have also been renamed to match.