### PR TITLE
Simplify enums

### DIFF
--- a/pkg/animations/animations.go
+++ b/pkg/animations/animations.go
@@ -7,7 +7,7 @@ package animations
 type Animation int
 
 const (
-	Arc Animation = iota + 100
+	Arc Animation = iota
 	Arrow
 	Baloon
 	Baloon2

--- a/pkg/colors/colors.go
+++ b/pkg/colors/colors.go
@@ -9,10 +9,10 @@ type Color int
 const (
 	// NoColor will bypass the color lookup causing characters to render
 	// with the current default of the terminal.
-	NoColor = 0
+	NoColor Color = iota
 
 	// FgHiGreen is a foreground high intensity green color.
-	FgHiGreen Color = iota + 20
+	FgHiGreen
 
 	// FgHiYellow is a foreground high intensity yellow color.
 	FgHiYellow


### PR DESCRIPTION
Prior to this PR the enums in colors and animations were defined with `iota` plus a random increment. This was useless and is not needed.

This PR removes the increment from the `iota` declaration.