### PR TITLE
Fix line updates

### DIFF
--- a/examples/advanced2/main.go
+++ b/examples/advanced2/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"time"
+
+	"github.com/chelnak/ysmrr"
+)
+
+type App struct {
+	spinnerManager ysmrr.SpinnerManager
+}
+
+func (a *App) doMoreWork() {
+	s := a.spinnerManager.AddSpinner("Loading...DoMoreWork()")
+	time.Sleep(time.Second * 5)
+	s.UpdateMessage("Done")
+	s.Complete()
+}
+
+func (a *App) doWork() {
+
+	s := a.spinnerManager.AddSpinner("Loading...DoWork()")
+	time.Sleep(time.Second * 5)
+	s.UpdateMessage("its Done")
+	s.Complete()
+
+	a.doMoreWork()
+}
+
+func (a *App) Run() {
+	a.spinnerManager.Start()
+	s := a.spinnerManager.AddSpinner("Loading...Run()")
+	a.doWork()
+	s.UpdateMessage("Loading...Run() Done")
+	s.Complete()
+}
+
+func (a *App) Stop() {
+	defer a.spinnerManager.Stop()
+}
+
+func NewApp() *App {
+	return &App{
+		spinnerManager: ysmrr.NewSpinnerManager(),
+	}
+}
+
+func main() {
+
+	app := NewApp()
+	app.Run()
+	app.Stop()
+
+}

--- a/manager.go
+++ b/manager.go
@@ -95,6 +95,7 @@ func (sm *spinnerManager) Stop() {
 
 	// Persist the final frame for each spinner.
 	for _, s := range sm.spinners {
+		tput.ClearLine(sm.writer)
 		s.Print(sm.writer, sm.chars[sm.frame])
 	}
 }
@@ -172,6 +173,7 @@ outer:
 
 func (sm *spinnerManager) renderFrame() {
 	for _, s := range sm.spinners {
+		tput.ClearLine(sm.writer)
 		s.Print(sm.writer, sm.chars[sm.frame])
 	}
 	sm.setNextFrame()

--- a/pkg/tput/tput.go
+++ b/pkg/tput/tput.go
@@ -42,6 +42,10 @@ func BufScreen(w io.Writer, n int) {
 	writef(w, "%s", strings.Repeat("\n", n))
 }
 
+func ClearLine(w io.Writer) {
+	write(w, "\u001b[K")
+}
+
 func tty() bool {
 	return isatty.IsTerminal(os.Stdout.Fd()) || os.Getenv("YSMRR_FORCE_TTY") == "true"
 }

--- a/pkg/tput/tput_test.go
+++ b/pkg/tput/tput_test.go
@@ -48,6 +48,11 @@ func TestTput(t *testing.T) {
 			fn:   tput.Cnorm,
 			want: "\u001b[?25h",
 		},
+		{
+			name: "ClearLine",
+			fn:   tput.ClearLine,
+			want: "\u001b[K",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Prior to this PR, lines were not properly cleared. This meant that updating the message of a spinner could result in text being incorrectly displayed. This would have been more noticeable when the updated message was shorter than the original message.

This commit fixes that by adding a new ClearLine method to the tput package and using it to ensure that each line is cleared before it is rendered.