### PR TITLE
Add UpdateMessagef() method

### DIFF
--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -49,8 +49,13 @@ func main() {
 }
 
 func downloader(wg *sync.WaitGroup, s *ysmrr.Spinner) {
-	s.UpdateMessage("Downloading...")
-	time.Sleep(2 * time.Second)
+	files := []string{"file1", "file2", "file3", "file4", "file5"}
+	for _, file := range files {
+		s.UpdateMessagef("Downloading %s...", file)
+		time.Sleep(1 * time.Second)
+	}
+
+	s.UpdateMessage("Downloading complete...")
 	s.Complete()
 }
 

--- a/spinner.go
+++ b/spinner.go
@@ -37,6 +37,11 @@ func (s *Spinner) UpdateMessage(message string) {
 	s.message = message
 }
 
+// UpdateMessagef updates the spinner message with a formatted string.
+func (s *Spinner) UpdateMessagef(format string, a ...interface{}) {
+	s.UpdateMessage(fmt.Sprintf(format, a...))
+}
+
 // IsComplete returns true if the spinner is complete.
 func (s *Spinner) IsComplete() bool {
 	s.mutex.Lock()

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -52,6 +52,14 @@ func TestSpinnerUpdateMessage(t *testing.T) {
 	assert.Equal(t, updatedMessage, spinner.GetMessage())
 }
 
+func TestSpinnerUpdateMessagef(t *testing.T) {
+	expectedMessage := "updated message test"
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	spinner.UpdateMessagef("updated message %s", "test")
+	assert.Equal(t, expectedMessage, spinner.GetMessage())
+}
+
 func TestSpinnerComplete(t *testing.T) {
 	opts := initialOpts
 	spinner := ysmrr.NewSpinner(opts)


### PR DESCRIPTION
Prior to this PR it was not possible to pass a formatted string to update the message of a spinner. The consumer would have to assign the result of `fmt.Sprintf()` to a variable and then pass it as a parameter to UpdateMessage().

This PR adds the `UpdateMessagef()` method so that consumers can update spinner messages with a formatted string.