### PR TITLE
fix race condition in `(*Spinner).Print`

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -33,8 +33,8 @@ type SpinnerManager interface {
 }
 
 type spinnerManager struct {
-	spinners   []*Spinner
-	spinnersMu sync.RWMutex
+	spinners []*Spinner
+	mutex    sync.RWMutex
 
 	chars         []string
 	frameDuration time.Duration
@@ -62,17 +62,17 @@ func (sm *spinnerManager) AddSpinner(message string) *Spinner {
 	}
 	spinner := NewSpinner(opts)
 
-	sm.spinnersMu.Lock()
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
 	sm.spinners = append(sm.spinners, spinner)
-	sm.spinnersMu.Unlock()
 
 	return spinner
 }
 
 // GetSpinners returns the spinners managed by the manager.
 func (sm *spinnerManager) GetSpinners() []*Spinner {
-	sm.spinnersMu.RLock()
-	defer sm.spinnersMu.RUnlock()
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
 	return sm.spinners
 }
 
@@ -105,8 +105,8 @@ func (sm *spinnerManager) Stop() {
 	sm.ticks.Stop()
 
 	// Persist the final frame for each spinner.
-	sm.spinnersMu.Lock()
-	defer sm.spinnersMu.Unlock()
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
 	for _, s := range sm.spinners {
 		tput.ClearLine(sm.writer)
 		s.Print(sm.writer, sm.chars[sm.frame])

--- a/spinner.go
+++ b/spinner.go
@@ -85,6 +85,8 @@ func (s *Spinner) Print(w io.Writer, char string) {
 		print(w, char, s.spinnerColor)
 	}
 
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	message := fmt.Sprintf(" %s\r\n", s.message)
 	print(w, message, s.messageColor)
 }


### PR DESCRIPTION
Hey! Started using this repo after needing multiple spinners (migrated from `yacspin`) and noticed a race condition caused by `(*Spinner).Print(` when `UpdateMessage(` is used from different goroutines.

I can add a test that reproduces this race detector failure if you'd like, too. 