### PR TITLE
Enhance complete and error methods

### DIFF
--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -69,6 +69,5 @@ func installer(wg *sync.WaitGroup, s *ysmrr.Spinner) {
 func runner(wg *sync.WaitGroup, s *ysmrr.Spinner) {
 	s.UpdateMessage("Running...")
 	time.Sleep(8 * time.Second)
-	s.Error()
-	s.UpdateMessage("Running encountered an error...")
+	s.ErrorWithMessage("Running encountered an error...")
 }

--- a/examples/advanced2/main.go
+++ b/examples/advanced2/main.go
@@ -13,15 +13,13 @@ type App struct {
 func (a *App) doMoreWork() {
 	s := a.spinnerManager.AddSpinner("Loading...DoMoreWork()")
 	time.Sleep(time.Second * 5)
-	s.UpdateMessage("Done")
-	s.Complete()
+	s.CompleteWithMessage("Done")
 }
 
 func (a *App) doWork() {
 	s := a.spinnerManager.AddSpinner("Loading...DoWork()")
 	time.Sleep(time.Second * 5)
-	s.UpdateMessage("its Done")
-	s.Complete()
+	s.CompleteWithMessage("It's Done")
 
 	a.doMoreWork()
 }
@@ -30,8 +28,7 @@ func (a *App) Run() {
 	a.spinnerManager.Start()
 	s := a.spinnerManager.AddSpinner("Loading...Run()")
 	a.doWork()
-	s.UpdateMessage("Loading...Run() Done")
-	s.Complete()
+	s.CompleteWithMessage("Loading...Run() Done")
 }
 
 func (a *App) Stop() {

--- a/spinner.go
+++ b/spinner.go
@@ -59,12 +59,38 @@ func (s *Spinner) IsError() bool {
 	return s.err
 }
 
+// CompleteWithMessage marks the spinner as complete with a message.
+func (s *Spinner) CompleteWithMessage(message string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.message = message
+	s.complete = true
+}
+
+// CompleteWithMessagef marks the spinner as complete with a formatted string.
+func (s *Spinner) CompleteWithMessagef(format string, a ...interface{}) {
+	s.CompleteWithMessage(fmt.Sprintf(format, a...))
+}
+
 // Complete marks the spinner as complete.
 func (s *Spinner) Complete() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
 	s.complete = true
+}
+
+// ErrorWithMessage marks the spinner as error with a message.
+func (s *Spinner) ErrorWithMessage(message string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.message = message
+	s.err = true
+}
+
+// ErrorWithMessagef marks the spinner as error with a formatted string.
+func (s *Spinner) ErrorWithMessagef(format string, a ...interface{}) {
+	s.ErrorWithMessage(fmt.Sprintf(format, a...))
 }
 
 // Error marks the spinner as error.

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -61,11 +61,43 @@ func TestSpinnerUpdateMessagef(t *testing.T) {
 	assert.Equal(t, expectedMessage, spinner.GetMessage())
 }
 
+func TestSpinnerCompleteWithMessage(t *testing.T) {
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	spinner.CompleteWithMessage("complete")
+	assert.Equal(t, true, spinner.IsComplete())
+	assert.Equal(t, "complete", spinner.GetMessage())
+}
+
+func TestSpinnerCompleteWithMessagef(t *testing.T) {
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	spinner.CompleteWithMessagef("complete %s", "test")
+	assert.Equal(t, true, spinner.IsComplete())
+	assert.Equal(t, "complete test", spinner.GetMessage())
+}
+
 func TestSpinnerComplete(t *testing.T) {
 	opts := initialOpts
 	spinner := ysmrr.NewSpinner(opts)
 	spinner.Complete()
 	assert.Equal(t, true, spinner.IsComplete())
+}
+
+func TestSpinnerErrorWithMessage(t *testing.T) {
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	spinner.ErrorWithMessage("error")
+	assert.Equal(t, true, spinner.IsError())
+	assert.Equal(t, "error", spinner.GetMessage())
+}
+
+func TestSpinnerErrorWithMessagef(t *testing.T) {
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	spinner.ErrorWithMessagef("error %s", "test")
+	assert.Equal(t, true, spinner.IsError())
+	assert.Equal(t, "error test", spinner.GetMessage())
 }
 
 func TestSpinnerError(t *testing.T) {


### PR DESCRIPTION
Prior to this change a user of this package would need to call UpdateMessage if they wanted to update the spinner with a message after either Complete or Error had been called.

This change introduces four new functions that will allow users to control messages when marking a spinner as Complete or in an Error state.

```
ErrorWithMessage(..)
ErrorWithMessagef(..)
CompleteWithMessage(..)
CompleteWithMessagef(..)
```