### PR TITLE
add a prefix to spinner

### DIFF
--- a/examples/basic_with_prefix/main.go
+++ b/examples/basic_with_prefix/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"time"
+
+	"github.com/chelnak/ysmrr"
+	"github.com/chelnak/ysmrr/pkg/animations"
+	"github.com/chelnak/ysmrr/pkg/colors"
+)
+
+func main() {
+	// Create a new spinner manager
+	sm := ysmrr.NewSpinnerManager(
+		ysmrr.WithAnimation(animations.Arrow),
+		ysmrr.WithSpinnerColor(colors.FgHiBlue),
+		ysmrr.WithMessageColor(colors.FgHiYellow),
+	)
+
+	// Set up our spinner
+	example := sm.AddSpinner("this text is after the spinner")
+
+	// Add a prefix
+	example.UpdatePrefix("this text is before the spinner")
+
+	// Start the spinners that have been added to the group
+	sm.Start()
+	defer sm.Stop()
+
+	// Set spinner to complete
+	time.Sleep(2 * time.Second)
+	example.Complete()
+}

--- a/examples/indented_spinners/main.go
+++ b/examples/indented_spinners/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/chelnak/ysmrr"
+)
+
+func main() {
+	// Create a new spinner manager
+	sm := ysmrr.NewSpinnerManager()
+
+	// Setup a group of spinners
+	spinners := make(map[int]*ysmrr.Spinner, 5)
+	spinners[0] = sm.AddSpinner("Worker Group")
+	for i := 1; i <= 4; i++ {
+		spinners[i] = sm.AddSpinner("worker" + strconv.Itoa(i))
+
+		// Indent worker spinners
+		spinners[i].UpdatePrefix("  ")
+	}
+
+	// Start the spinners that have been added to the group
+	sm.Start()
+	defer sm.Stop()
+
+	// Simulate work
+	for i := 1; i <= 4; i++ {
+		time.Sleep(2 * time.Second)
+		spinners[i].Complete()
+	}
+
+	// All the workers are done, set status of group
+	spinners[0].Complete()
+}

--- a/spinner.go
+++ b/spinner.go
@@ -17,6 +17,7 @@ type Spinner struct {
 	errorColor    *color.Color
 	messageColor  *color.Color
 	message       string
+	prefix        string
 	complete      bool
 	err           bool
 	hasUpdate     chan bool
@@ -41,6 +42,27 @@ func (s *Spinner) UpdateMessage(message string) {
 // UpdateMessagef updates the spinner message with a formatted string.
 func (s *Spinner) UpdateMessagef(format string, a ...interface{}) {
 	s.UpdateMessage(fmt.Sprintf(format, a...))
+}
+
+// GetPrefix returns the current spinner Prefix.
+func (s *Spinner) GetPrefix() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.prefix
+}
+
+// UpdatePrefix updates the spinner Prefix.
+func (s *Spinner) UpdatePrefix(Prefix string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.prefix = Prefix
+	s.notifyHasUpdate()
+}
+
+// UpdatePrefixf updates the spinner Prefix with a formatted string.
+func (s *Spinner) UpdatePrefixf(format string, a ...interface{}) {
+	s.UpdatePrefix(fmt.Sprintf(format, a...))
 }
 
 // IsComplete returns true if the spinner is complete.
@@ -103,6 +125,8 @@ func (s *Spinner) Error() {
 
 // Print prints the spinner at a given position.
 func (s *Spinner) Print(w io.Writer, char string) {
+	print(w, s.prefix, s.completeColor)
+
 	if s.IsComplete() {
 		print(w, "✓", s.completeColor)
 	} else if s.IsError() {

--- a/spinner.go
+++ b/spinner.go
@@ -125,7 +125,7 @@ func (s *Spinner) Error() {
 
 // Print prints the spinner at a given position.
 func (s *Spinner) Print(w io.Writer, char string) {
-	print(w, s.prefix, s.completeColor)
+	print(w, s.prefix, s.messageColor)
 
 	if s.IsComplete() {
 		print(w, "✓", s.completeColor)

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -33,6 +33,12 @@ func TestSpinnerGetMessage(t *testing.T) {
 	assert.Equal(t, initialMessage, spinner.GetMessage())
 }
 
+func TestSpinnerGetPrefix(t *testing.T) {
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	assert.Equal(t, "", spinner.GetPrefix())
+}
+
 func TestSpinnerIsError(t *testing.T) {
 	opts := initialOpts
 	spinner := ysmrr.NewSpinner(opts)
@@ -59,6 +65,22 @@ func TestSpinnerUpdateMessagef(t *testing.T) {
 	spinner := ysmrr.NewSpinner(opts)
 	spinner.UpdateMessagef("updated message %s", "test")
 	assert.Equal(t, expectedMessage, spinner.GetMessage())
+}
+
+func TestSpinnerUpdatePrefix(t *testing.T) {
+	expectedPrefix := "prefix"
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	spinner.UpdatePrefix(expectedPrefix)
+	assert.Equal(t, expectedPrefix, spinner.GetPrefix())
+}
+
+func TestSpinnerUpdatePrefixf(t *testing.T) {
+	expectedPrefix := "prefix test"
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+	spinner.UpdatePrefixf("prefix %s", "test")
+	assert.Equal(t, expectedPrefix, spinner.GetPrefix())
 }
 
 func TestSpinnerCompleteWithMessage(t *testing.T) {
@@ -116,6 +138,21 @@ func TestPrint(t *testing.T) {
 	spinner.Print(&buf, dots[0])
 
 	want := fmt.Sprintf("%s %s\r\n", dots[0], initialMessage)
+	assert.Equal(t, want, buf.String())
+}
+
+func TestPrintWithPrefix(t *testing.T) {
+	opts := initialOpts
+	spinner := ysmrr.NewSpinner(opts)
+
+	prefix := "prefix"
+	spinner.UpdatePrefix(prefix)
+
+	var buf bytes.Buffer
+	_, dots := animations.GetAnimation(animations.Dots)
+	spinner.Print(&buf, dots[0])
+
+	want := fmt.Sprintf("%s%s %s\r\n", prefix, dots[0], initialMessage)
 	assert.Equal(t, want, buf.String())
 }
 


### PR DESCRIPTION
Add the ability to set the text before a spinner

For my use I wanted to be able to indent certain spinners
![Screenshot 2023-11-27 at 4 30 08 PM](https://github.com/chelnak/ysmrr/assets/22667398/f891d711-c6aa-4d20-9622-30c7ab8460d8)

This seemed like it would be useful to have in general