### PR TITLE
Add running state to spinner manager, allow running Stop multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ sm.Start()
 sm.Stop()
 ```
 
+Running `Stop()` on a stopped spinner group is a noop operation.
+
+#### Checking if a spinner group is running
+
+```go
+sm := ysmrr.NewSpinnerManager()
+sm.Start()
+isRunning := sm.Running() // true
+sm.Stop()
+isRunning = sm.Running() // false
+```
+
 ### Spinners
 
 `SpinnerManagers` are great but pretty useless on their own. You need to add at least one spinner.
@@ -111,8 +123,8 @@ For more usage examples, check out the [examples](examples) directory.
 
 Ysmrr was inspired by the following projects:
 
-* [github.com/briandowns/spinner](https://github.com/briandowns/spinner)
-* [github.com/theckman/yacspin](https://github.com/theckman/yacspin)
+- [github.com/briandowns/spinner](https://github.com/briandowns/spinner)
+- [github.com/theckman/yacspin](https://github.com/theckman/yacspin)
 
 It also uses [github.com/fatih/color](https://github.com/fatih/color) for the underlying color system
 and [github.com/mattn/go-colorable](https://github.com/mattn/go-colorable) for Windows support.

--- a/manager.go
+++ b/manager.go
@@ -95,6 +95,7 @@ func (sm *spinnerManager) Stop() {
 	}
 	sm.done <- true
 	sm.ticks.Stop()
+	sm.running = false
 
 	// Persist the final frame for each spinner.
 	sm.mutex.Lock()
@@ -165,7 +166,6 @@ outer:
 	for {
 		select {
 		case <-sm.done:
-			sm.running = false
 			break outer
 		case <-sm.hasUpdate:
 			sm.renderFrame(false)

--- a/manager_test.go
+++ b/manager_test.go
@@ -127,3 +127,20 @@ func TestManagerConcurrentSpinnerUsage(t *testing.T) {
 
 	spinnerManager.Stop()
 }
+
+func TestManagerRunning(t *testing.T) {
+	spinnerManager := ysmrr.NewSpinnerManager()
+	assert.False(t, spinnerManager.Running())
+	spinnerManager.Start()
+	assert.True(t, spinnerManager.Running())
+	spinnerManager.Stop()
+	assert.False(t, spinnerManager.Running())
+}
+
+func TestManagerStopTwice(t *testing.T) {
+	spinnerManager := ysmrr.NewSpinnerManager()
+	spinnerManager.Start()
+	spinnerManager.AddSpinner("test")
+	spinnerManager.Stop()
+	spinnerManager.Stop()
+}


### PR DESCRIPTION
fix: add checks to Stop() to make it noop if the spinner manager is already stopped

I was running `Stop()` in a cleanup function and it had already been called in a `defer` somewhere else. This caused the program to be stuck because it could no longer communicate to the `render()` function through the channel. This change adds a `running` attribute used to determine if the spinner manager is running and return early from `Stop()` if it isn't.

feat: add Running() method to determine the running state of the spinner

It's just for convenience.
